### PR TITLE
Lock rxjs version to same version as @angular-devkit uses

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@angular-devkit/core": "^7.0.5",
     "@angular-devkit/schematics": "^7.0.5",
     "@schematics/angular": "^7.0.5",
-    "rxjs": "^6.3.3"
+    "rxjs": "~6.3.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Running

```shell
$ git clone https://github.com/briebug/jest-schematic
...
$ cd jest-schematic/
$ npm install
...
$ npm run build
```

results in error

```shell
src/jest/index.ts(46,3): error TS2322: Type '(tree: Tree, context: TypedSchematicContext<{}, {}>) => Observable<Tree>' is not assignable to type 'Rule'.
  Type 'Observable<Tree>' is not assignable to type 'void | Tree | Rule | Observable<Tree>'.
    Type 'import("C:/github/jest-schematic/node_modules/rxjs/internal/Observable").Observable<import("C:/github/jest-schematic/node_modules/@angular-devkit/schematics/src/tree/interface").Tree>' is not assignable to type 'import("C:/github/jest-schematic/node_modules/@angular-devkit/core/node_modules/rxjs/internal/Observable").Observable<import("C:/github/jest-schematic/node_modules/@angular-devkit/schematics/src/tree/interface").Tree>'.
      Types of property 'source' are incompatible.
        Type 'import("C:/github/jest-schematic/node_modules/rxjs/internal/Observable").Observable<any>' is not assignable to type 'import("C:/github/jest-schematic/node_modules/@angular-devkit/core/node_modules/rxjs/internal/Observable").Observable<any>'.
          Types of property 'operator' are incompatible.
            Type 'import("C:/github/jest-schematic/node_modules/rxjs/internal/Operator").Operator<any, any>' is not assignable to type 'import("C:/github/jest-schematic/node_modules/@angular-devkit/core/node_modules/rxjs/internal/Operator").Operator<any, any>'.
              Types of property 'call' are incompatible.
                Type '(subscriber: import("C:/github/jest-schematic/node_modules/rxjs/internal/Subscriber").Subscriber<any>, source: any) => import("C:/github/jest-schematic/node_modules/rxjs/internal/types").TeardownLogic' is not assignable to type '(subscriber: import("C:/github/jest-schematic/node_modules/@angular-devkit/core/node_modules/rxjs/internal/Subscriber").Subscriber<any>, source: any) => import("C:/github/jest-schematic/node_modules/@angular-devkit/core/node_modules/rxjs/internal/types").TeardownLogic'.
                  Types of parameters 'subscriber' and 'subscriber' are incompatible.
                    Property '_parentOrParents' is missing in type 'Subscriber<any>' but required in type 'Subscriber<any>'.
```

which is due to rxjs version incompatibilities between 6.3.3 and 6.5.3. So lock to 6.3.x.
