### PR TITLE
fix: projects without builders error 

### DIFF
--- a/sandboxes/single-app/angular.json
+++ b/sandboxes/single-app/angular.json
@@ -107,6 +107,25 @@
           }
         }
       }
+    },
+    "test2-e2e": {
+      "root": "e2e/",
+      "projectType": "application",
+      "prefix": "",
+      "architect": {
+        "e2e": {
+          "builder": "@angular-devkit/build-angular:protractor",
+          "options": {
+            "protractorConfig": "e2e/protractor.conf.js",
+            "devServerTarget": "test2:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "test2:serve:production"
+            }
+          }
+        }
+      }
     }
   },
   "defaultProject": "sandbox"

--- a/src/jest/index.ts
+++ b/src/jest/index.ts
@@ -127,9 +127,11 @@ function updateAngularJson(): Rule {
     Object.values(angularJson.projects as Record<string, any>).forEach((o) => {
       const { test } = o?.architect;
 
-      test.builder = '@angular-builders/jest:run';
-      delete test.options.main;
-      delete test.options.karmaConfig;
+      if (test?.builder) {
+        test.builder = '@angular-builders/jest:run';
+        delete test.options.main;
+        delete test.options.karmaConfig;
+      }
     });
 
     // todo use project formatter or an ast update strategy to avoid formatting irrelevant fields
@@ -170,6 +172,7 @@ function configureTsConfig(): Rule {
 
     Object.values(angularJson.projects as Record<string, any>)
       .map((o) => o?.architect?.test?.options?.tsConfig as string)
+      .filter((path) => !!path)
       .forEach((path) => {
         const json = readJsonInTree<TsConfigSchema>(tree, path);
 


### PR DESCRIPTION
- Check that a projects `builder` & `tsConfig` path exists before trying to modify the settings

Fixes #42 