### PR TITLE
fix(schematics): add removeDependencies for karma deps

### DIFF
--- a/src/jest/index.ts
+++ b/src/jest/index.ts
@@ -53,6 +53,7 @@ function updateDependencies(): Rule {
       'karma-jasmine',
       'karma-jasmine-html-reporter',
       'karma-chrome-launcher',
+      'karma-coverage',
       'karma-coverage-istanbul-reporter'
     ).pipe(
       map((packageName: string) => {


### PR DESCRIPTION
Add karma-coverage to removeDependencies.
The package was added in Angular v11. Instead of karma-coverage-istanbul-reporter.