### PR TITLE
renames parameter tsConfig to tsconfig to stay compatible with ts-jest versions >= 27

### DIFF
--- a/src/jest/workspace-files/jest.config.js
+++ b/src/jest/workspace-files/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   ...baseConfig,
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/<%= path %>/tsconfig.spec.json',
+      tsconfig: '<rootDir>/<%= path %>/tsconfig.spec.json',
     },
   },
 };


### PR DESCRIPTION
according to https://kulshekhar.github.io/ts-jest/docs/getting-started/options#options the parameter "tsConfig" will be deprecated with version 27 of ts-jest.

To stay compatible and make updating easier it would be great to have a future-proof version of ```jest.config.js``` from the beginning.