### PR TITLE
fix(schema): follow new angular 12 schematics

### DIFF
--- a/src/jest/schema.json
+++ b/src/jest/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "BriebugSchematicsJest",
+  "$id": "BriebugSchematicsJest",
   "title": "Jest Install Options Schema",
   "type": "object",
   "properties": {},


### PR DESCRIPTION
Fixes the following deprecation warning for Angular 12 projcet

```sh
"JestRunnerSchema" schema is using the keyword "id" which its support is deprecated. Use "$id" for schema ID.
```