### PR TITLE
fix(jest): import angular template correctly

### DIFF
--- a/src/jest/files/setup-jest.ts
+++ b/src/jest/files/setup-jest.ts
@@ -1,4 +1,4 @@
-import 'jest-preset-angular';
+import 'jest-preset-angular/setup-jest';
 
 /* global mocks for jsdom */
 const mock = () => {


### PR DESCRIPTION
This will fix the following deprecation warning

```sh
ts-jest[root] (WARN) Import setup jest file via `import 'jest-preset-angular';` is deprecated and will be removed in v9.0.0. Please switch to `import 'jest-preset-angular/setup-jest';`
```