### PR TITLE
fix(jest-config): import test jest-preset-angular setup from right path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 'circleci/node:12.9.1-browsers'
+      - image: 'circleci/node:lts-browsers'
     steps:
       - checkout
       # Download and cache dependencies
@@ -22,7 +22,7 @@ jobs:
 
   test-single-app:
     docker:
-      - image: 'circleci/node:12.9.1-browsers'
+      - image: 'circleci/node:lts-browsers'
     steps:
       - checkout
       # Download and cache dependencies
@@ -37,7 +37,7 @@ jobs:
 
   test-workspace-app-lib:
     docker:
-      - image: 'circleci/node:12.9.1-browsers'
+      - image: 'circleci/node:lts-browsers'
     steps:
       - checkout
       # Download and cache dependencies

--- a/src/jest/files/setup-jest.ts
+++ b/src/jest/files/setup-jest.ts
@@ -1,4 +1,4 @@
-import 'jest-preset-angular';
+import 'jest-preset-angular/setup-jest';
 
 /* global mocks for jsdom */
 const mock = () => {


### PR DESCRIPTION
The new `jest-preset-angular' has a separated scrip to setup the test environment.
See details in [jest-preset-angular](https://github.com/thymikee/jest-preset-angular#configuration) documentation.