### PR TITLE
Use $id instead of id in schematic schema.

### DIFF
--- a/src/jest/schema.json
+++ b/src/jest/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "BriebugSchematicsJest",
+  "$id": "BriebugSchematicsJest",
   "title": "Jest Install Options Schema",
   "type": "object",
   "properties": {},


### PR DESCRIPTION
Fix #77 Correct for use with angular 13.